### PR TITLE
Implement Bento text-to-image UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Text-to-Image UI
+
+This repository provides a simple web UI for interacting with a text-to-image model served with BentoML.
+
+## Running the Service
+
+1. Install dependencies:
+   ```bash
+   pip install bentoml pillow
+   ```
+2. Start the Bento service:
+   ```bash
+   bentoml serve service:svc
+   ```
+
+The service exposes a `POST /generate` endpoint that accepts a JSON payload with a `prompt` field and returns an image.
+
+## Using the UI
+
+Open `ui/index.html` in your browser. Enter a prompt and submit. The page will call the API endpoint and display the generated image.
+
+This project contains only a placeholder image generator. Integrate your text-to-image model inside `service.py` where noted.

--- a/service.py
+++ b/service.py
@@ -1,0 +1,17 @@
+import bentoml
+from bentoml.io import JSON, Image
+from PIL import Image as PILImage
+
+svc = bentoml.Service("text_to_image_service")
+
+@svc.api(input=JSON(), output=Image())
+def generate(data: dict) -> PILImage.Image:
+    """Generate an image from a text prompt.
+
+    This implementation returns a placeholder image. Replace the body with your
+    text-to-image model inference code.
+    """
+    prompt = data.get("prompt", "")
+    # TODO: integrate real text-to-image model using `prompt`
+    img = PILImage.new("RGB", (512, 512), color="white")
+    return img

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Text to Image</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        #result { margin-top: 1em; }
+    </style>
+</head>
+<body>
+    <h1>Text to Image</h1>
+    <input type="text" id="prompt" placeholder="Enter prompt" size="50">
+    <button onclick="generate()">Generate</button>
+    <div id="result"></div>
+
+    <script>
+        async function generate() {
+            const prompt = document.getElementById('prompt').value;
+            const response = await fetch('/generate', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ prompt })
+            });
+            if (!response.ok) {
+                alert('Request failed');
+                return;
+            }
+            const blob = await response.blob();
+            const url = URL.createObjectURL(blob);
+            document.getElementById('result').innerHTML = `<img src="${url}" width="512" height="512">`;
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add instructions in README
- create Bento service to generate placeholder images
- build a simple HTML frontend

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68410eadd9f083259a4bc7de86d92b91